### PR TITLE
path.normalize("#{files.orig.dest}") on windows

### DIFF
--- a/tasks/asset-fingerprint.coffee
+++ b/tasks/asset-fingerprint.coffee
@@ -7,7 +7,7 @@ _      = require "lodash"
 
 module.exports = (grunt) ->
   stripDestPath = (file, files) ->
-    file.replace(path.normalize("#{files.orig.dest}/"), "")
+    file.replace("#{files.orig.dest}/", "")
 
   contentWithHashSubstitutions = (file, hashMap, cdnPrefixForRootPaths) ->
     originalContent = grunt.file.read(file)


### PR DESCRIPTION
on Windows the `path.normalize("#{files.orig.dest}")` in `stripDestPath()` causes asset URLs in generated files to not be rewritten due to the fact that URLs always have '/''s which does not align with windows directory slashes - in the default situation you get "files\" ... which will never match.

I assume that the path.normalize is in there to fudge any ./ or ../ ... but is that really necessary here? I'm guessing it is not.
